### PR TITLE
Fix readme typos and code issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is an updated fork of [wizardfrag/mc-ping](https://github.com/wizar
 
 You can use it as follows:
 
-    mcping = require('mc-ping-updated');
+    const mcping = require('mc-ping-updated');
 
     mcping('example.com', 25565, function(err, res) {
     	if (err) {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mcping('example.com', 25565, function(err, res) {
 	if (err) {
     		// Some kind of error
     		console.error(err);
-    	} else {
+	} else {
     		// Success!
     		console.log(res);
 	}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is an updated fork of [wizardfrag/mc-ping](https://github.com/wizar
 
 You can use it as follows:
 
-    mcping = require('mc-ping');
+    mcping = require('mc-ping-updated');
 
     mcping('example.com', 25565, function(err, res) {
     	if (err) {

--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@
 This library is an updated fork of [wizardfrag/mc-ping](https://github.com/wizardfrag/mc-ping) that supports Minecraft 1.8's protocol. mc-ping (and subsequently, mc-ping-updated) is a super-simple library that provides access to the [Server List Ping](http://wiki.vg/Server_List_Ping) feature of Minecraft PC servers.
 
 You can use it as follows:
+```javascript
+const mcping = require('mc-ping-updated');
 
-    const mcping = require('mc-ping-updated');
-
-    mcping('example.com', 25565, function(err, res) {
-    	if (err) {
+mcping('example.com', 25565, function(err, res) {
+	if (err) {
     		// Some kind of error
     		console.error(err);
     	} else {
     		// Success!
     		console.log(res);
-    	}
-	}, 3000);
+	}
+}, 3000);
+```
 
 If the request completes, `res` will be a JSON object like so: [http://wiki.vg/Server_List_Ping#Response](http://wiki.vg/Server_List_Ping#Response)
 


### PR DESCRIPTION
The old method was requiring the outdated mc-ping, replaced with the name in npmjs.org